### PR TITLE
Port to Windows10 VS2017

### DIFF
--- a/Encryptions/AES.cpp
+++ b/Encryptions/AES.cpp
@@ -77,7 +77,7 @@ uint8_t AES::GF(uint8_t a, uint8_t b){
     From Wikipedia*/
     uint8_t prim = 0x1b;
     uint8_t p = 0, i = 0;
-    while ((i < 8) && (a != 0) and (b != 0)){
+    while ((i < 8) && (a != 0) && (b != 0)){
         if (b & 1){
             p ^= a;
         }

--- a/common/includes.h
+++ b/common/includes.h
@@ -10,6 +10,7 @@ Some functions were heavily influenced by python 2.7.2
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <algorithm>
 
 // Some useful constants
 static const std::string zero(1, 0);


### PR DESCRIPTION
std::min requires the algorithm header

Replace and with && for consistency, in any case it breaks on VS2017